### PR TITLE
Add first round match announcement for players

### DIFF
--- a/app/player/dashboard/page.js
+++ b/app/player/dashboard/page.js
@@ -41,8 +41,8 @@ export default function PlayerDashboard() {
         if (profileData.player) {
           setPlayer(profileData.player)
           
-          // Check for first round matches
-          const matchesResponse = await fetch('/api/player/matches/schedule')
+          // Check for first round matches - FIXED ENDPOINT
+          const matchesResponse = await fetch('/api/player/matches')
           if (matchesResponse.ok) {
             const matchesData = await matchesResponse.json()
             const firstRound = matchesData.matches?.find(match => match.round === 1)

--- a/app/player/matches/page.js
+++ b/app/player/matches/page.js
@@ -275,8 +275,8 @@ export default function PlayerMatches() {
     }
     
     const message = language === 'es' 
-      ? `Hola ${opponentName}! Soy ${player?.name} de la liga de tenis. ¿Cuándo te viene bien para jugar nuestro partido de la ronda ${selectedMatch?.round}?`
-      : `Hi ${opponentName}! I'm ${player?.name} from the tennis league. When would be a good time to play our round ${selectedMatch?.round} match?`
+      ? `Hola ${opponentName}! Soy ${player?.name} de TDP liga de tenis. ¿Cuándo te viene bien para jugar nuestro partido de la ronda ${selectedMatch?.round}?`
+      : `Hi ${opponentName}! I'm ${player?.name} from the TDP tennis league. When would be a good time to play our round ${selectedMatch?.round} match?`
     
     return `https://wa.me/${cleaned}?text=${encodeURIComponent(message)}`
   }

--- a/app/player/messages/page.js
+++ b/app/player/messages/page.js
@@ -40,8 +40,8 @@ export default function MessagesPage() {
         const profileData = await profileResponse.json()
         setPlayer(profileData.player)
         
-        // Check for first round matches
-        const matchesResponse = await fetch('/api/player/matches/schedule')
+        // Check for first round matches - FIXED ENDPOINT
+        const matchesResponse = await fetch('/api/player/matches')
         if (matchesResponse.ok) {
           const matchesData = await matchesResponse.json()
           const firstRound = matchesData.matches?.find(match => match.round === 1)

--- a/lib/content/announcementContent.js
+++ b/lib/content/announcementContent.js
@@ -77,6 +77,9 @@ export const announcementContent = {
       getContent: (playerName, opponentName, opponentWhatsapp, matchDetails) => {
         // Normalize the phone number for WhatsApp
         const normalizedPhone = normalizePhoneForWhatsApp(opponentWhatsapp)
+        // Create the message template - same as used in matches page
+        const whatsappMessage = `Hola ${opponentName}! Soy ${playerName} de la liga de tenis. ¿Cuándo te viene bien para jugar nuestro partido de la ronda 1?`
+        const whatsappUrl = `https://wa.me/${normalizedPhone}?text=${encodeURIComponent(whatsappMessage)}`
         
         return `
         <p class="mb-4">
@@ -105,7 +108,7 @@ export const announcementContent = {
         
         <div class="bg-green-50 rounded-lg p-4 mb-4">
           <p class="font-semibold mb-2">📱 Contacta con tu rival:</p>
-          <a href="https://wa.me/${normalizedPhone}" target="_blank" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors">
+          <a href="${whatsappUrl}" target="_blank" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors">
             <svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24">
               <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z"/>
             </svg>
@@ -141,6 +144,9 @@ export const announcementContent = {
       getContent: (playerName, opponentName, opponentWhatsapp, matchDetails) => {
         // Normalize the phone number for WhatsApp
         const normalizedPhone = normalizePhoneForWhatsApp(opponentWhatsapp)
+        // Create the message template - same as used in matches page
+        const whatsappMessage = `Hi ${opponentName}! I'm ${playerName} from the tennis league. When would be a good time to play our round 1 match?`
+        const whatsappUrl = `https://wa.me/${normalizedPhone}?text=${encodeURIComponent(whatsappMessage)}`
         
         return `
         <p class="mb-4">
@@ -169,7 +175,7 @@ export const announcementContent = {
         
         <div class="bg-green-50 rounded-lg p-4 mb-4">
           <p class="font-semibold mb-2">📱 Contact your opponent:</p>
-          <a href="https://wa.me/${normalizedPhone}" target="_blank" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors">
+          <a href="${whatsappUrl}" target="_blank" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors">
             <svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24">
               <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z"/>
             </svg>

--- a/lib/content/announcementContent.js
+++ b/lib/content/announcementContent.js
@@ -1,3 +1,5 @@
+import { normalizePhoneForWhatsApp } from '../utils/phoneUtils'
+
 export const announcementContent = {
   firstRoundDelay: {
     id: 'first-round-delay-2025',
@@ -72,7 +74,11 @@ export const announcementContent = {
     es: {
       title: '¡Tu primer partido está listo! 🎾',
       subtitle: 'Es hora de conocer a tu rival',
-      getContent: (playerName, opponentName, opponentWhatsapp, matchDetails) => `
+      getContent: (playerName, opponentName, opponentWhatsapp, matchDetails) => {
+        // Normalize the phone number for WhatsApp
+        const normalizedPhone = normalizePhoneForWhatsApp(opponentWhatsapp)
+        
+        return `
         <p class="mb-4">
           ¡Hola <strong>${playerName}</strong>! 🎉
         </p>
@@ -99,7 +105,7 @@ export const announcementContent = {
         
         <div class="bg-green-50 rounded-lg p-4 mb-4">
           <p class="font-semibold mb-2">📱 Contacta con tu rival:</p>
-          <a href="https://wa.me/${opponentWhatsapp}" target="_blank" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors">
+          <a href="https://wa.me/${normalizedPhone}" target="_blank" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors">
             <svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24">
               <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z"/>
             </svg>
@@ -125,13 +131,18 @@ export const announcementContent = {
         <p class="text-sm text-gray-600">
           ¡Mucha suerte y que gane el mejor! 🏆
         </p>
-      `,
+      `
+      },
       buttonText: '¡Vamos a jugar!'
     },
     en: {
       title: 'Your first match is ready! 🎾',
       subtitle: 'Time to meet your opponent',
-      getContent: (playerName, opponentName, opponentWhatsapp, matchDetails) => `
+      getContent: (playerName, opponentName, opponentWhatsapp, matchDetails) => {
+        // Normalize the phone number for WhatsApp
+        const normalizedPhone = normalizePhoneForWhatsApp(opponentWhatsapp)
+        
+        return `
         <p class="mb-4">
           Hello <strong>${playerName}</strong>! 🎉
         </p>
@@ -158,7 +169,7 @@ export const announcementContent = {
         
         <div class="bg-green-50 rounded-lg p-4 mb-4">
           <p class="font-semibold mb-2">📱 Contact your opponent:</p>
-          <a href="https://wa.me/${opponentWhatsapp}" target="_blank" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors">
+          <a href="https://wa.me/${normalizedPhone}" target="_blank" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors">
             <svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24">
               <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z"/>
             </svg>
@@ -184,7 +195,8 @@ export const announcementContent = {
         <p class="text-sm text-gray-600">
           Good luck and may the best player win! 🏆
         </p>
-      `,
+      `
+      },
       buttonText: "Let's play!"
     }
   }

--- a/lib/content/announcementContent.js
+++ b/lib/content/announcementContent.js
@@ -64,5 +64,128 @@ export const announcementContent = {
       `,
       buttonText: 'Got it, thanks!'
     }
+  },
+  firstRoundMatch: {
+    id: 'first-round-match-2025',
+    date: new Date('2025-01-07T10:00:00'),
+    dynamic: true, // This announcement needs dynamic content per player
+    es: {
+      title: '¡Tu primer partido está listo! 🎾',
+      subtitle: 'Es hora de conocer a tu rival',
+      getContent: (playerName, opponentName, opponentWhatsapp, matchDetails) => `
+        <p class="mb-4">
+          ¡Hola <strong>${playerName}</strong>! 🎉
+        </p>
+        <p class="mb-4">
+          ¡La espera ha terminado! Tu primer partido de la <strong>Liga del Parque Sotogrande</strong> ya está programado.
+        </p>
+        <div class="bg-parque-purple/10 rounded-lg p-4 mb-4">
+          <p class="text-lg font-semibold mb-2">🎾 Tu rival de la Primera Ronda:</p>
+          <p class="text-xl font-bold text-parque-purple mb-3">${opponentName}</p>
+          
+          <div class="space-y-2">
+            <p class="flex items-center text-sm">
+              <span class="mr-2">📅</span>
+              <span><strong>Ronda:</strong> Primera Ronda</span>
+            </p>
+            ${matchDetails?.level ? `
+            <p class="flex items-center text-sm">
+              <span class="mr-2">🏆</span>
+              <span><strong>Nivel:</strong> ${matchDetails.level}</span>
+            </p>
+            ` : ''}
+          </div>
+        </div>
+        
+        <div class="bg-green-50 rounded-lg p-4 mb-4">
+          <p class="font-semibold mb-2">📱 Contacta con tu rival:</p>
+          <a href="https://wa.me/${opponentWhatsapp}" target="_blank" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors">
+            <svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z"/>
+            </svg>
+            Enviar mensaje por WhatsApp
+          </a>
+        </div>
+        
+        <div class="bg-blue-50 rounded-lg p-4 mb-4">
+          <p class="font-semibold mb-2">📋 Próximos pasos:</p>
+          <ol class="list-decimal list-inside space-y-1 text-sm">
+            <li>Contacta con ${opponentName} para acordar fecha y hora</li>
+            <li>Reservad una pista (cada jugador paga la mitad)</li>
+            <li>Jugad el partido antes del final de la ronda</li>
+            <li>El ganador reporta el resultado en la plataforma</li>
+          </ol>
+        </div>
+        
+        <p class="mb-4">
+          <strong>Recuerda:</strong> Tienes varias semanas para jugar este partido. 
+          ¡Coordina con tu rival y encuentra el mejor momento para ambos!
+        </p>
+        
+        <p class="text-sm text-gray-600">
+          ¡Mucha suerte y que gane el mejor! 🏆
+        </p>
+      `,
+      buttonText: '¡Vamos a jugar!'
+    },
+    en: {
+      title: 'Your first match is ready! 🎾',
+      subtitle: 'Time to meet your opponent',
+      getContent: (playerName, opponentName, opponentWhatsapp, matchDetails) => `
+        <p class="mb-4">
+          Hello <strong>${playerName}</strong>! 🎉
+        </p>
+        <p class="mb-4">
+          The wait is over! Your first match in the <strong>Liga del Parque Sotogrande</strong> is now scheduled.
+        </p>
+        <div class="bg-parque-purple/10 rounded-lg p-4 mb-4">
+          <p class="text-lg font-semibold mb-2">🎾 Your First Round opponent:</p>
+          <p class="text-xl font-bold text-parque-purple mb-3">${opponentName}</p>
+          
+          <div class="space-y-2">
+            <p class="flex items-center text-sm">
+              <span class="mr-2">📅</span>
+              <span><strong>Round:</strong> First Round</span>
+            </p>
+            ${matchDetails?.level ? `
+            <p class="flex items-center text-sm">
+              <span class="mr-2">🏆</span>
+              <span><strong>Level:</strong> ${matchDetails.level}</span>
+            </p>
+            ` : ''}
+          </div>
+        </div>
+        
+        <div class="bg-green-50 rounded-lg p-4 mb-4">
+          <p class="font-semibold mb-2">📱 Contact your opponent:</p>
+          <a href="https://wa.me/${opponentWhatsapp}" target="_blank" class="inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors">
+            <svg class="w-5 h-5 mr-2" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z"/>
+            </svg>
+            Send WhatsApp message
+          </a>
+        </div>
+        
+        <div class="bg-blue-50 rounded-lg p-4 mb-4">
+          <p class="font-semibold mb-2">📋 Next steps:</p>
+          <ol class="list-decimal list-inside space-y-1 text-sm">
+            <li>Contact ${opponentName} to arrange date and time</li>
+            <li>Book a court (each player pays half)</li>
+            <li>Play the match before the round ends</li>
+            <li>The winner reports the result on the platform</li>
+          </ol>
+        </div>
+        
+        <p class="mb-4">
+          <strong>Remember:</strong> You have several weeks to play this match. 
+          Coordinate with your opponent and find the best time for both!
+        </p>
+        
+        <p class="text-sm text-gray-600">
+          Good luck and may the best player win! 🏆
+        </p>
+      `,
+      buttonText: "Let's play!"
+    }
   }
 };


### PR DESCRIPTION
## Description

This PR adds a new announcement feature for first round matches. When players log in and have a first round match scheduled, they will see a one-time announcement modal with:
- Their opponent's name
- WhatsApp contact button
- Instructions on how to proceed with scheduling the match

## Changes

1. **Updated `announcementContent.js`:**
   - Added new `firstRoundMatch` announcement with dynamic content generation
   - Supports both Spanish and English with personalized messages

2. **Updated Player Dashboard:**
   - Added logic to check for first round matches on login
   - Shows announcement modal if player hasn't seen it yet
   - Marks announcement as seen after viewing

3. **Updated Messages Page:**
   - Displays the first round match announcement in the messages list
   - Shows as "New" if not yet viewed
   - Properly handles dynamic content generation

## Features

- ✅ One-time display after login
- ✅ Bilingual support (ES/EN)
- ✅ Dynamic content with player and opponent information
- ✅ WhatsApp integration for easy contact
- ✅ Persistent tracking (won't show again after viewing)
- ✅ Available in messages page for future reference

## Testing

1. Create a first round match for a player
2. Log in as that player
3. Verify the announcement modal appears
4. Check that it doesn't appear again on subsequent logins
5. Verify it's listed in the messages page