### PR TITLE
fix: Games statistics not showing on standings page

### DIFF
--- a/docs/GAMES_STATISTICS_FIX.md
+++ b/docs/GAMES_STATISTICS_FIX.md
@@ -1,0 +1,92 @@
+# Games Statistics Fix
+
+## Problem
+
+The standings page was showing "0-0" for games won/lost for all players, even when they had played matches and won/lost games.
+
+## Root Cause
+
+When match results were entered, the system was correctly updating:
+- Match wins/losses
+- Sets won/lost
+- ELO ratings
+
+However, it was **not** calculating and updating the individual games won/lost within each set.
+
+## Solution
+
+### 1. Updated Match Result Processing
+
+Modified `/app/api/admin/matches/[id]/route.js` to:
+- Count games from each set when a match result is entered
+- Update both players' `gamesWon` and `gamesLost` statistics
+- Handle walkover matches (winner gets 12-0 in games)
+
+### 2. Recalculation Script
+
+Created `/scripts/recalculateGamesStats.js` to:
+- Recalculate games statistics for all existing completed matches
+- Reset all players' games stats to 0 first
+- Process each match and count games from set scores
+- Update player statistics accordingly
+
+## Implementation Details
+
+### Code Changes
+
+```javascript
+// Count games from sets
+let player1GamesWon = 0
+let player2GamesWon = 0
+
+if (body.result.score && body.result.score.sets && body.result.score.sets.length > 0) {
+  // Count games from each set
+  body.result.score.sets.forEach(set => {
+    player1GamesWon += set.player1
+    player2GamesWon += set.player2
+  })
+} else if (body.result.score && body.result.score.walkover) {
+  // For walkover, winner gets 12-0 (6-0, 6-0)
+  player1GamesWon = player1Won ? 12 : 0
+  player2GamesWon = player1Won ? 0 : 12
+}
+
+// Update player statistics
+player1.stats.gamesWon = (player1.stats.gamesWon || 0) + player1GamesWon
+player1.stats.gamesLost = (player1.stats.gamesLost || 0) + player2GamesWon
+
+player2.stats.gamesWon = (player2.stats.gamesWon || 0) + player2GamesWon
+player2.stats.gamesLost = (player2.stats.gamesLost || 0) + player1GamesWon
+```
+
+## Usage
+
+### For New Matches
+Games statistics will be automatically calculated when match results are entered going forward.
+
+### For Existing Matches
+Run the recalculation script to update historical data:
+
+```bash
+npm run recalculate:games
+```
+
+This will:
+1. Connect to the database
+2. Reset all players' games statistics
+3. Process all completed matches
+4. Calculate and update games won/lost for each player
+5. Display a summary of the update
+
+## Testing
+
+1. Enter a match result with scores like 6-4, 6-3
+2. Check the standings page
+3. Player 1 should show 12-7 games
+4. Player 2 should show 7-12 games
+
+## Files Modified
+
+- `/app/api/admin/matches/[id]/route.js` - Added games calculation to match result processing
+- `/scripts/recalculateGamesStats.js` - New script to fix existing data
+- `/package.json` - Added `recalculate:games` script command

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "tree": "node scripts/tree.js",
     "seed:leagues": "node scripts/seedLeagues.js",
-    "create-admin": "node scripts/createAdminUser.js"
+    "create-admin": "node scripts/createAdminUser.js",
+    "recalculate:games": "node scripts/recalculateGamesStats.js"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/scripts/recalculateGamesStats.js
+++ b/scripts/recalculateGamesStats.js
@@ -1,0 +1,148 @@
+const mongoose = require('mongoose')
+const dotenv = require('dotenv')
+
+// Load environment variables
+dotenv.config({ path: '.env.local' })
+
+// Define schemas inline
+const PlayerSchema = new mongoose.Schema({
+  name: String,
+  email: String,
+  stats: {
+    matchesPlayed: { type: Number, default: 0 },
+    matchesWon: { type: Number, default: 0 },
+    totalPoints: { type: Number, default: 0 },
+    eloRating: { type: Number },
+    setsWon: { type: Number, default: 0 },
+    setsLost: { type: Number, default: 0 },
+    gamesWon: { type: Number, default: 0 },
+    gamesLost: { type: Number, default: 0 }
+  }
+})
+
+const MatchSchema = new mongoose.Schema({
+  players: {
+    player1: { type: mongoose.Schema.Types.ObjectId, ref: 'Player' },
+    player2: { type: mongoose.Schema.Types.ObjectId, ref: 'Player' }
+  },
+  result: {
+    winner: mongoose.Schema.Types.ObjectId,
+    score: {
+      sets: [{
+        player1: Number,
+        player2: Number
+      }],
+      walkover: Boolean
+    }
+  },
+  status: String
+})
+
+// Create models
+const Player = mongoose.models.Player || mongoose.model('Player', PlayerSchema)
+const Match = mongoose.models.Match || mongoose.model('Match', MatchSchema)
+
+async function recalculateGamesStatistics() {
+  try {
+    // Connect to MongoDB
+    await mongoose.connect(process.env.MONGODB_URI)
+    console.log('Connected to MongoDB')
+
+    // Reset all players' games statistics
+    const resetResult = await Player.updateMany(
+      {},
+      { 
+        $set: { 
+          'stats.gamesWon': 0, 
+          'stats.gamesLost': 0 
+        } 
+      }
+    )
+    console.log(`Reset games statistics for ${resetResult.modifiedCount} players`)
+
+    // Get all completed matches
+    const matches = await Match.find({ 
+      status: 'completed',
+      'result.winner': { $exists: true }
+    }).populate('players.player1 players.player2')
+
+    console.log(`Found ${matches.length} completed matches to process`)
+
+    let processedCount = 0
+    let errorCount = 0
+
+    // Process each match
+    for (const match of matches) {
+      try {
+        const player1Id = match.players.player1._id.toString()
+        const player2Id = match.players.player2._id.toString()
+        const player1Won = match.result.winner.toString() === player1Id
+
+        let player1GamesWon = 0
+        let player2GamesWon = 0
+
+        if (match.result.score && match.result.score.sets && match.result.score.sets.length > 0) {
+          // Count games from sets
+          match.result.score.sets.forEach(set => {
+            player1GamesWon += set.player1 || 0
+            player2GamesWon += set.player2 || 0
+          })
+        } else if (match.result.score && match.result.score.walkover) {
+          // For walkover, winner gets 12-0 (6-0, 6-0)
+          player1GamesWon = player1Won ? 12 : 0
+          player2GamesWon = player1Won ? 0 : 12
+        }
+
+        // Update player statistics
+        await Player.findByIdAndUpdate(player1Id, {
+          $inc: {
+            'stats.gamesWon': player1GamesWon,
+            'stats.gamesLost': player2GamesWon
+          }
+        })
+
+        await Player.findByIdAndUpdate(player2Id, {
+          $inc: {
+            'stats.gamesWon': player2GamesWon,
+            'stats.gamesLost': player1GamesWon
+          }
+        })
+
+        processedCount++
+        
+        if (processedCount % 10 === 0) {
+          console.log(`Processed ${processedCount} matches...`)
+        }
+      } catch (error) {
+        console.error(`Error processing match ${match._id}:`, error.message)
+        errorCount++
+      }
+    }
+
+    console.log('\n✅ Recalculation complete!')
+    console.log(`- Processed: ${processedCount} matches`)
+    console.log(`- Errors: ${errorCount} matches`)
+
+    // Show sample of updated players
+    const samplePlayers = await Player.find({
+      $or: [
+        { 'stats.gamesWon': { $gt: 0 } },
+        { 'stats.gamesLost': { $gt: 0 } }
+      ]
+    }).limit(5).select('name stats.gamesWon stats.gamesLost')
+
+    console.log('\nSample of updated players:')
+    samplePlayers.forEach(player => {
+      console.log(`- ${player.name}: ${player.stats.gamesWon}-${player.stats.gamesLost} games`)
+    })
+
+  } catch (error) {
+    console.error('Script error:', error)
+  } finally {
+    await mongoose.connection.close()
+    console.log('\nDatabase connection closed')
+  }
+}
+
+// Run the script
+recalculateGamesStatistics()


### PR DESCRIPTION
## Summary

This PR fixes the issue where games won/lost statistics were always showing as "0-0" on the standings page, even when players had completed matches with game scores.

## Problem

The user reported:
> "on the standings page we currently dont show 'games' accurately. Its always 0-0 now, even if user has some matches and games won and lost"

## Root Cause

When match results were entered, the system was updating:
- ✅ Match wins/losses
- ✅ Sets won/lost  
- ✅ ELO ratings
- ❌ **Games won/lost** (missing)

The code was only counting sets but not the individual games within each set.

## Solution

### 1. **Fixed Match Result Processing**
Updated `/app/api/admin/matches/[id]/route.js` to:
- Calculate total games won/lost from set scores
- Update player statistics with game counts
- Handle walkover matches (winner gets 12-0 in games)

### 2. **Added Recalculation Script**
Created `/scripts/recalculateGamesStats.js` to:
- Fix existing historical data
- Reset and recalculate games statistics for all completed matches
- Process matches in bulk with error handling

### 3. **Added NPM Command**
- `npm run recalculate:games` - Run the recalculation script

## Testing

1. **For new matches**: Enter a match result (e.g., 6-4, 7-5)
   - Player 1 should show 13-9 games
   - Player 2 should show 9-13 games

2. **For existing matches**: Run `npm run recalculate:games`
   - All historical match data will be updated
   - Games statistics will reflect actual scores

## Files Changed

- `/app/api/admin/matches/[id]/route.js` - Added games calculation logic
- `/scripts/recalculateGamesStats.js` - New script for historical data
- `/package.json` - Added recalculate command
- `/docs/GAMES_STATISTICS_FIX.md` - Documentation

## Screenshots

### Before
Games always showing as 0-0

### After  
Games showing actual won/lost counts based on set scores