### PR TITLE
fix: Calculate games dynamically from match scores in standings

### DIFF
--- a/docs/GAMES_STATISTICS_FIX_DYNAMIC.md
+++ b/docs/GAMES_STATISTICS_FIX_DYNAMIC.md
@@ -1,0 +1,69 @@
+# Games Statistics Fix - Dynamic Calculation
+
+## Problem
+
+The standings page was showing "0-0" for games won/lost because it was using stored values from the Player model (`player.stats.gamesWon` and `player.stats.gamesLost`) which were not being populated.
+
+## Initial Approach (Incorrect)
+
+Initially, I tried to:
+1. Update games statistics when match results are entered
+2. Store games won/lost in the Player model
+3. Create a recalculation script for existing data
+
+However, this approach was wrong because the standings are already calculating points dynamically from match data, so games should be calculated the same way.
+
+## Correct Solution
+
+Modified the standings endpoint (`/app/api/leagues/[league]/standings/route.js`) to calculate games dynamically from match scores, just like it calculates points.
+
+### Implementation
+
+```javascript
+// Calculate points and games from each match
+matches.forEach(match => {
+  // ... existing point calculation ...
+  
+  // Calculate games from match score
+  let player1GamesWon = 0
+  let player2GamesWon = 0
+  
+  if (match.result && match.result.score) {
+    if (match.result.score.sets && match.result.score.sets.length > 0) {
+      // Count games from each set
+      match.result.score.sets.forEach(set => {
+        player1GamesWon += (set.player1 || 0)
+        player2GamesWon += (set.player2 || 0)
+      })
+    } else if (match.result.score.walkover) {
+      // For walkover, winner gets 12-0 (6-0, 6-0)
+      const player1Won = match.result.winner.toString() === player1Id
+      player1GamesWon = player1Won ? 12 : 0
+      player2GamesWon = player1Won ? 0 : 12
+    }
+  }
+  
+  // Update calculated stats
+  stats.gamesWon += player1GamesWon
+  stats.gamesLost += player2GamesWon
+})
+```
+
+## Benefits
+
+1. **Single Source of Truth**: Match data is the only source for game statistics
+2. **Always Accurate**: No sync issues between stored and actual data
+3. **Consistent Pattern**: Games are calculated the same way as points
+4. **No Migration Needed**: Works immediately for all existing matches
+
+## Testing
+
+1. Enter a match result (e.g., 6-4, 7-5)
+2. Check the standings page
+3. Games should show correctly calculated values (13-9 and 9-13)
+
+## Files Changed
+
+- `/app/api/leagues/[league]/standings/route.js` - Modified to calculate games dynamically
+
+This is a much cleaner solution that follows the existing pattern of calculating statistics on-the-fly from match data.


### PR DESCRIPTION
## Summary

This PR fixes the issue where games won/lost statistics were showing as "0-0" on the standings page by calculating them dynamically from match scores, following the same pattern used for points calculation.

## Problem

The standings page was showing "0-0" for games because it was using stored values from the Player model (`player.stats.gamesWon/gamesLost`) which were not being populated.

## Why This is the Correct Fix

The standings endpoint already calculates points dynamically from match data. Games should be calculated the same way to maintain:
- **Single source of truth** (match scores)
- **No sync issues** between stored and calculated data
- **Consistency** with existing patterns

## Solution

Modified `/app/api/leagues/[league]/standings/route.js` to:
1. Calculate games from match scores alongside points calculation
2. Count games from each set in completed matches
3. Handle walkover matches (winner gets 12-0)
4. Use calculated values instead of stored Player stats

## Implementation

```javascript
// Calculate games from match score
let player1GamesWon = 0
let player2GamesWon = 0

if (match.result.score.sets && match.result.score.sets.length > 0) {
  // Count games from each set
  match.result.score.sets.forEach(set => {
    player1GamesWon += (set.player1 || 0)
    player2GamesWon += (set.player2 || 0)
  })
}
```

## Testing

1. View any league standings page
2. Games won/lost will now show correct values calculated from match scores
3. Example: A match with scores 6-4, 7-5 will show 13-9 for winner, 9-13 for loser

## Benefits

- ✅ Works immediately for all existing matches
- ✅ No database migration needed
- ✅ No recalculation script needed
- ✅ Always accurate and up-to-date
- ✅ Follows existing architectural pattern

## Note

This replaces PR #38 which took the wrong approach of storing games in the Player model. This dynamic calculation is the correct solution.