### PR TITLE
Add Import/Export functionality for Leagues

### DIFF
--- a/app/api/admin/leagues/export/route.js
+++ b/app/api/admin/leagues/export/route.js
@@ -1,0 +1,91 @@
+import { NextResponse } from 'next/server'
+import clientPromise from '../../../../../lib/db'
+
+export async function GET() {
+  try {
+    const client = await clientPromise
+    const db = client.db(process.env.MONGODB_DB)
+    
+    // Get all leagues with their seasons
+    const leagues = await db.collection('leagues')
+      .find({})
+      .toArray()
+    
+    // Prepare CSV headers
+    const headers = [
+      'name',
+      'type',
+      'location_city',
+      'location_region',
+      'location_venue',
+      'surface',
+      'ball_type',
+      'match_format',
+      'season_name',
+      'season_status',
+      'created_at',
+      'updated_at'
+    ]
+    
+    // Convert leagues to CSV rows
+    const rows = []
+    
+    for (const league of leagues) {
+      if (league.seasons && league.seasons.length > 0) {
+        // Create a row for each season
+        for (const season of league.seasons) {
+          rows.push([
+            league.name,
+            league.type || 'public',
+            league.location?.city || '',
+            league.location?.region || '',
+            league.location?.venue || '',
+            league.settings?.surface || 'clay',
+            league.settings?.ballType || 'pressurized',
+            league.settings?.matchFormat || 'best_of_3',
+            season.name || '',
+            season.status || 'draft',
+            league.createdAt ? new Date(league.createdAt).toISOString() : '',
+            league.updatedAt ? new Date(league.updatedAt).toISOString() : ''
+          ])
+        }
+      } else {
+        // Create a row for league without seasons
+        rows.push([
+          league.name,
+          league.type || 'public',
+          league.location?.city || '',
+          league.location?.region || '',
+          league.location?.venue || '',
+          league.settings?.surface || 'clay',
+          league.settings?.ballType || 'pressurized',
+          league.settings?.matchFormat || 'best_of_3',
+          '',
+          '',
+          league.createdAt ? new Date(league.createdAt).toISOString() : '',
+          league.updatedAt ? new Date(league.updatedAt).toISOString() : ''
+        ])
+      }
+    }
+    
+    // Create CSV content
+    const csvContent = [
+      headers.join(','),
+      ...rows.map(row => row.map(cell => `"${String(cell).replace(/"/g, '""')}"`).join(','))
+    ].join('\n')
+    
+    // Return CSV file
+    return new NextResponse(csvContent, {
+      headers: {
+        'Content-Type': 'text/csv',
+        'Content-Disposition': `attachment; filename="leagues-export-${new Date().toISOString().split('T')[0]}.csv"`
+      }
+    })
+  } catch (error) {
+    console.error('Export error:', error)
+    return NextResponse.json(
+      { error: 'Failed to export leagues' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/admin/leagues/export/route.js
+++ b/app/api/admin/leagues/export/route.js
@@ -1,15 +1,13 @@
 import { NextResponse } from 'next/server'
-import clientPromise from '../../../../../lib/db'
+import dbConnect from '../../../../../lib/db/mongoose'
+import League from '../../../../../lib/models/League'
 
 export async function GET() {
   try {
-    const client = await clientPromise
-    const db = client.db(process.env.MONGODB_DB)
+    await dbConnect()
     
     // Get all leagues with their seasons
-    const leagues = await db.collection('leagues')
-      .find({})
-      .toArray()
+    const leagues = await League.find({}).lean()
     
     // Prepare CSV headers
     const headers = [

--- a/app/api/admin/leagues/import/route.js
+++ b/app/api/admin/leagues/import/route.js
@@ -1,0 +1,166 @@
+import { NextResponse } from 'next/server'
+import clientPromise from '../../../../../lib/db'
+import { ObjectId } from 'mongodb'
+
+function parseCSV(csvText) {
+  const lines = csvText.trim().split('\n')
+  const headers = lines[0].split(',').map(h => h.trim().replace(/^"|"$/g, ''))
+  const data = []
+  
+  for (let i = 1; i < lines.length; i++) {
+    const values = []
+    let current = ''
+    let insideQuotes = false
+    
+    for (let j = 0; j < lines[i].length; j++) {
+      const char = lines[i][j]
+      
+      if (char === '"') {
+        if (insideQuotes && lines[i][j + 1] === '"') {
+          current += '"'
+          j++
+        } else {
+          insideQuotes = !insideQuotes
+        }
+      } else if (char === ',' && !insideQuotes) {
+        values.push(current.trim())
+        current = ''
+      } else {
+        current += char
+      }
+    }
+    values.push(current.trim())
+    
+    const row = {}
+    headers.forEach((header, index) => {
+      row[header] = values[index] || ''
+    })
+    data.push(row)
+  }
+  
+  return data
+}
+
+export async function POST(request) {
+  try {
+    const formData = await request.formData()
+    const file = formData.get('file')
+    
+    if (!file) {
+      return NextResponse.json(
+        { error: 'No file uploaded' },
+        { status: 400 }
+      )
+    }
+    
+    const csvText = await file.text()
+    const leaguesData = parseCSV(csvText)
+    
+    if (leaguesData.length === 0) {
+      return NextResponse.json(
+        { error: 'CSV file is empty' },
+        { status: 400 }
+      )
+    }
+    
+    const client = await clientPromise
+    const db = client.db(process.env.MONGODB_DB)
+    const leaguesCollection = db.collection('leagues')
+    
+    let created = 0
+    let updated = 0
+    const errors = []
+    
+    // Group data by league name to handle multiple seasons
+    const leagueGroups = {}
+    leaguesData.forEach((row, index) => {
+      if (!row.name || !row.location_city || !row.location_region) {
+        errors.push(`Row ${index + 2}: Missing required fields (name, location_city, location_region)`)
+        return
+      }
+      
+      if (!leagueGroups[row.name]) {
+        leagueGroups[row.name] = {
+          basicInfo: row,
+          seasons: []
+        }
+      }
+      
+      if (row.season_name) {
+        leagueGroups[row.name].seasons.push({
+          name: row.season_name,
+          status: row.season_status || 'draft'
+        })
+      }
+    })
+    
+    // Process each league
+    for (const [leagueName, leagueData] of Object.entries(leagueGroups)) {
+      const { basicInfo, seasons } = leagueData
+      
+      try {
+        // Check if league exists
+        const existingLeague = await leaguesCollection.findOne({ name: leagueName })
+        
+        const leagueDoc = {
+          name: leagueName,
+          type: basicInfo.type || 'public',
+          location: {
+            city: basicInfo.location_city,
+            region: basicInfo.location_region,
+            venue: basicInfo.location_venue || ''
+          },
+          settings: {
+            surface: basicInfo.surface || 'clay',
+            ballType: basicInfo.ball_type || 'pressurized',
+            matchFormat: basicInfo.match_format || 'best_of_3'
+          },
+          seasons: seasons.length > 0 ? seasons.map(s => ({
+            _id: new ObjectId(),
+            ...s,
+            createdAt: new Date(),
+            updatedAt: new Date()
+          })) : [],
+          updatedAt: new Date()
+        }
+        
+        if (existingLeague) {
+          // Update existing league
+          await leaguesCollection.updateOne(
+            { _id: existingLeague._id },
+            { 
+              $set: {
+                ...leagueDoc,
+                seasons: existingLeague.seasons ? [...existingLeague.seasons, ...leagueDoc.seasons] : leagueDoc.seasons
+              }
+            }
+          )
+          updated++
+        } else {
+          // Create new league
+          await leaguesCollection.insertOne({
+            ...leagueDoc,
+            createdAt: new Date()
+          })
+          created++
+        }
+      } catch (error) {
+        errors.push(`Failed to process league "${leagueName}": ${error.message}`)
+      }
+    }
+    
+    return NextResponse.json({
+      success: true,
+      message: `Import completed: ${created} created, ${updated} updated`,
+      created,
+      updated,
+      errors
+    })
+  } catch (error) {
+    console.error('Import error:', error)
+    return NextResponse.json(
+      { error: 'Failed to import leagues', details: error.message },
+      { status: 500 }
+    )
+  }
+}

--- a/components/admin/leagues/ImportCSVModal.js
+++ b/components/admin/leagues/ImportCSVModal.js
@@ -1,0 +1,150 @@
+import React, { useState } from 'react'
+
+export default function ImportCSVModal({ 
+  show, 
+  onClose, 
+  onImport, 
+  importResult 
+}) {
+  const [file, setFile] = useState(null)
+  const [importing, setImporting] = useState(false)
+
+  if (!show) return null
+
+  const handleFileSelect = (e) => {
+    const selectedFile = e.target.files[0]
+    if (selectedFile && selectedFile.type === 'text/csv') {
+      setFile(selectedFile)
+    } else {
+      alert('Please select a CSV file')
+    }
+  }
+
+  const handleImport = async () => {
+    if (!file) return
+
+    setImporting(true)
+    try {
+      await onImport(file)
+    } finally {
+      setImporting(false)
+    }
+  }
+
+  const handleClose = () => {
+    setFile(null)
+    setImporting(false)
+    onClose()
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg p-6 max-w-lg w-full mx-4">
+        <h3 className="text-lg font-semibold mb-4">Import Leagues from CSV</h3>
+        
+        {!importResult ? (
+          <>
+            <div className="mb-4">
+              <p className="text-sm text-gray-600 mb-4">
+                Upload a CSV file with league data. The CSV should have the following columns:
+              </p>
+              <ul className="text-sm text-gray-600 list-disc list-inside mb-4">
+                <li>name (required)</li>
+                <li>type (public/private)</li>
+                <li>location_city (required)</li>
+                <li>location_region (required)</li>
+                <li>location_venue</li>
+                <li>surface (clay/hard/grass)</li>
+                <li>ball_type (pressurized/depressurized)</li>
+                <li>match_format (best_of_3/best_of_5/single_set)</li>
+                <li>season_name</li>
+                <li>season_status (draft/registration_open/active/completed)</li>
+              </ul>
+              <div className="mb-2">
+                <a 
+                  href="/leagues-import-template.csv" 
+                  download
+                  className="text-sm text-blue-600 hover:text-blue-800 underline"
+                >
+                  Download CSV template
+                </a>
+              </div>
+            </div>
+
+            <div className="mb-4">
+              <input
+                type="file"
+                accept=".csv"
+                onChange={handleFileSelect}
+                className="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
+              />
+              {file && (
+                <p className="mt-2 text-sm text-gray-600">
+                  Selected: {file.name}
+                </p>
+              )}
+            </div>
+
+            <div className="mb-4 p-3 bg-blue-50 border border-blue-200 rounded-lg">
+              <p className="text-sm text-blue-800">
+                <strong>Note:</strong> If a league with the same name already exists, its information will be updated. 
+                Each league can include season information which will be created or updated accordingly.
+              </p>
+            </div>
+
+            <div className="flex justify-end space-x-3">
+              <button
+                onClick={handleClose}
+                className="px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50"
+                disabled={importing}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleImport}
+                disabled={!file || importing}
+                className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {importing ? 'Importing...' : 'Import'}
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className={`mb-4 p-4 rounded-lg ${importResult.success ? 'bg-green-50' : 'bg-red-50'}`}>
+              <p className={`text-sm font-medium ${importResult.success ? 'text-green-800' : 'text-red-800'}`}>
+                {importResult.message}
+              </p>
+              {importResult.success && (
+                <div className="mt-2 text-sm text-green-700">
+                  <p>Created: {importResult.created || 0} leagues</p>
+                  <p>Updated: {importResult.updated || 0} leagues</p>
+                </div>
+              )}
+            </div>
+
+            {importResult.errors && importResult.errors.length > 0 && (
+              <div className="mb-4">
+                <p className="text-sm font-medium text-gray-700 mb-2">Errors:</p>
+                <div className="max-h-40 overflow-y-auto bg-gray-50 p-2 rounded text-sm">
+                  {importResult.errors.map((error, index) => (
+                    <p key={index} className="text-red-600">{error}</p>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div className="flex justify-end">
+              <button
+                onClick={handleClose}
+                className="px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700"
+              >
+                Close
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/lib/hooks/useLeaguesData.js
+++ b/lib/hooks/useLeaguesData.js
@@ -1,0 +1,78 @@
+import { useState, useEffect } from 'react'
+
+export default function useLeaguesData() {
+  const [leagues, setLeagues] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  const fetchLeagues = async () => {
+    try {
+      setLoading(true)
+      const res = await fetch('/api/admin/leagues', { cache: 'no-store' })
+      if (!res.ok) throw new Error('Failed to fetch leagues')
+      
+      const data = await res.json()
+      setLeagues(data.leagues || [])
+    } catch (error) {
+      console.error('Error fetching leagues:', error)
+      setError('Error loading leagues')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchLeagues()
+  }, [])
+
+  const handleImportCSV = async (file) => {
+    const formData = new FormData()
+    formData.append('file', file)
+
+    try {
+      const res = await fetch('/api/admin/leagues/import', {
+        method: 'POST',
+        body: formData
+      })
+
+      const data = await res.json()
+
+      if (res.ok) {
+        fetchLeagues() // Refresh leagues list
+        return {
+          success: true,
+          message: data.message,
+          created: data.created,
+          updated: data.updated,
+          errors: data.errors
+        }
+      } else {
+        return {
+          success: false,
+          message: data.error || 'Import failed',
+          errors: data.errors
+        }
+      }
+    } catch (error) {
+      console.error('Error importing leagues:', error)
+      return {
+        success: false,
+        message: 'Error importing leagues',
+        errors: []
+      }
+    }
+  }
+
+  const exportCSV = () => {
+    window.location.href = '/api/admin/leagues/export'
+  }
+
+  return {
+    leagues,
+    loading,
+    error,
+    handleImportCSV,
+    exportCSV,
+    refetch: fetchLeagues
+  }
+}

--- a/public/leagues-import-template.csv
+++ b/public/leagues-import-template.csv
@@ -1,0 +1,3 @@
+"name","type","location_city","location_region","location_venue","surface","ball_type","match_format","season_name","season_status"
+"Example Tennis League","public","Madrid","Madrid","Central Park Courts","clay","pressurized","best_of_3","Spring 2025","registration_open"
+"Elite Players League","private","Barcelona","Catalonia","Olympic Tennis Center","hard","depressurized","best_of_5","Winter Season","active"


### PR DESCRIPTION
## Feature: Leagues Import/Export Functionality

This PR adds import and export functionality for leagues in the admin panel, similar to what already exists for players and matches.

### Changes:
- **New Hook**: Created `useLeaguesData` hook to handle leagues data management and import/export operations
- **Import Modal**: Added `ImportCSVModal` component for leagues with appropriate fields
- **Updated Leagues Page**: Modified the admin leagues page to include Import/Export buttons and functionality
- **API Endpoints**: 
  - `/api/admin/leagues/export` - Exports all leagues to CSV format
  - `/api/admin/leagues/import` - Imports leagues from CSV file
- **CSV Template**: Added template file in public directory for easy reference

### Features:
- Export all leagues with their seasons to CSV
- Import leagues from CSV with support for:
  - Basic league information (name, type, location)
  - League settings (surface, ball type, match format)
  - Season information (can import multiple seasons per league)
- Update existing leagues if they already exist (matched by name)
- Proper error handling and user feedback
- CSV template download for easy formatting

### CSV Format:
The import/export supports the following fields:
- `name` (required)
- `type` (public/private)
- `location_city` (required)
- `location_region` (required)
- `location_venue`
- `surface` (clay/hard/grass)
- `ball_type` (pressurized/depressurized)
- `match_format` (best_of_3/best_of_5/single_set)
- `season_name`
- `season_status` (draft/registration_open/active/completed)

### Testing:
1. Navigate to Admin > Leagues
2. Click "Export CSV" to download current leagues
3. Click "Import CSV" to upload a CSV file
4. Download the template for proper formatting

This implementation follows the same pattern as the existing players import/export functionality for consistency.