### PR TITLE
Fix: Show all match results instead of limiting to 10

### DIFF
--- a/app/[location]/liga/[season]/page.js
+++ b/app/[location]/liga/[season]/page.js
@@ -433,8 +433,8 @@ export default function LeagueSeasonPage() {
         setStandings(standingsData)
       }
       
-      // Fetch recent matches
-      const matchesRes = await fetch(`/api/leagues/${location}/matches?season=${dbSeason}&status=completed&limit=10`)
+      // Fetch recent matches - INCREASED LIMIT FROM 10 TO 100
+      const matchesRes = await fetch(`/api/leagues/${location}/matches?season=${dbSeason}&status=completed&limit=100`)
       if (matchesRes.ok) {
         const matchesData = await matchesRes.json()
         setMatches(matchesData.matches || [])

--- a/app/api/leagues/[league]/matches/route.js
+++ b/app/api/leagues/[league]/matches/route.js
@@ -15,7 +15,7 @@ export async function GET(request, { params }) {
     const season = searchParams.get('season') || 'Verano 2025'
     const status = searchParams.get('status') // 'completed', 'scheduled', etc.
     const round = searchParams.get('round')
-    const limit = parseInt(searchParams.get('limit')) || 20
+    const limit = parseInt(searchParams.get('limit')) || 100 // INCREASED DEFAULT FROM 20 TO 100
     
     console.log('API: Fetching matches for league:', slug, 'season:', season, 'status:', status)
     

--- a/lib/hooks/useLeagueData.js
+++ b/lib/hooks/useLeagueData.js
@@ -67,7 +67,8 @@ export function useLeagueData() {
           setStandings(standingsData)
         }
         
-        const matchesRes = await fetch(`/api/leagues/${location}/matches?season=${dbSeasonName}&status=completed&limit=10`)
+        // INCREASED LIMIT FROM 10 TO 100
+        const matchesRes = await fetch(`/api/leagues/${location}/matches?season=${dbSeasonName}&status=completed&limit=100`)
         if (matchesRes.ok) {
           const matchesData = await matchesRes.json()
           setMatches(matchesData.matches || [])


### PR DESCRIPTION
## Problem
Match results are only showing up to July 16th/17th on both:
- Public league page: `/sotogrande/liga/verano2025` (Results tab)
- Player league page: `/player/league` (Results tab)

This was happening because the API calls were limiting the results to only 10 matches.

## Solution
Increased the match results limit from 10 to 100 in all relevant places:

1. **Public league page** (`app/[location]/liga/[season]/page.js`):
   - Changed `limit=10` to `limit=100` when fetching completed matches

2. **Player league hook** (`lib/hooks/useLeagueData.js`):
   - Changed `limit=10` to `limit=100` when fetching completed matches

3. **API endpoint** (`app/api/leagues/[league]/matches/route.js`):
   - Changed default limit from 20 to 100 to handle cases where limit is not specified

## Testing
After this change:
- All match results should now be visible in both the public and player league pages
- The Results tab should show all completed matches, not just the first 10

## Note
If there are more than 100 matches in the future, we may need to implement proper pagination. For now, 100 should be sufficient to show all matches for the current season.