### PR TITLE
Feature: Add search and round filters to player results pages

### DIFF
--- a/components/player/ResultsTab.js
+++ b/components/player/ResultsTab.js
@@ -1,15 +1,99 @@
-import React from 'react'
+import React, { useState, useMemo } from 'react'
 
 export default function ResultsTab({ matches, language }) {
+  const [filters, setFilters] = useState({
+    search: '',
+    round: 'all'
+  })
+
+  // Get unique rounds from matches
+  const rounds = useMemo(() => {
+    const uniqueRounds = [...new Set(matches.map(match => match.round))].sort((a, b) => b - a)
+    return uniqueRounds
+  }, [matches])
+
+  // Filter matches based on search and round
+  const filteredMatches = useMemo(() => {
+    return matches.filter(match => {
+      // Search filter
+      if (filters.search) {
+        const searchLower = filters.search.toLowerCase()
+        const player1Name = match.players.player1?.name?.toLowerCase() || ''
+        const player2Name = match.players.player2?.name?.toLowerCase() || ''
+        
+        if (!player1Name.includes(searchLower) && !player2Name.includes(searchLower)) {
+          return false
+        }
+      }
+
+      // Round filter
+      if (filters.round !== 'all' && match.round !== parseInt(filters.round)) {
+        return false
+      }
+
+      return true
+    })
+  }, [matches, filters])
+
+  const handleFilterChange = (newFilters) => {
+    setFilters(newFilters)
+  }
+
   return (
     <div>
       <h2 className="text-xl md:text-2xl font-bold text-parque-purple mb-4 md:mb-6">
         {language === 'es' ? 'Partidos Recientes' : 'Recent Matches'}
       </h2>
       
-      {matches && matches.length > 0 ? (
+      {/* Filters Section */}
+      <div className="bg-gray-50 rounded-lg p-4 mb-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {/* Search Input */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              {language === 'es' ? 'Buscar Jugadores' : 'Search Players'}
+            </label>
+            <input
+              type="text"
+              value={filters.search}
+              onChange={(e) => handleFilterChange({ ...filters, search: e.target.value })}
+              placeholder={language === 'es' ? 'Buscar por nombre de jugador...' : 'Search by player name...'}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-parque-purple focus:border-transparent"
+            />
+          </div>
+          
+          {/* Round Filter */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              {language === 'es' ? 'Ronda' : 'Round'}
+            </label>
+            <select
+              value={filters.round}
+              onChange={(e) => handleFilterChange({ ...filters, round: e.target.value })}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-parque-purple focus:border-transparent"
+            >
+              <option value="all">
+                {language === 'es' ? 'Todas las Rondas' : 'All Rounds'}
+              </option>
+              {rounds.map(round => (
+                <option key={round} value={round}>
+                  {language === 'es' ? `Ronda ${round}` : `Round ${round}`}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </div>
+
+      {/* Results Section */}
+      {filteredMatches && filteredMatches.length > 0 ? (
         <div className="space-y-4">
-          {matches.map((match) => (
+          <div className="text-sm text-gray-600 mb-2">
+            {language === 'es' 
+              ? `Mostrando ${filteredMatches.length} de ${matches.length} partidos`
+              : `Showing ${filteredMatches.length} of ${matches.length} matches`}
+          </div>
+          {filteredMatches.map((match) => (
             <div key={match._id} className="border rounded-lg p-6 hover:shadow-md transition-shadow">
               <div className="flex items-center justify-between">
                 <div className="flex-1">
@@ -75,6 +159,21 @@ export default function ResultsTab({ matches, language }) {
               </div>
             </div>
           ))}
+        </div>
+      ) : filteredMatches && filteredMatches.length === 0 && matches.length > 0 ? (
+        <div className="text-center py-12 text-gray-500">
+          <span className="text-4xl mb-4 block">🔍</span>
+          <p className="mb-2">
+            {language === 'es' 
+              ? 'No se encontraron partidos con los filtros seleccionados.'
+              : 'No matches found with the selected filters.'}
+          </p>
+          <button
+            onClick={() => setFilters({ search: '', round: 'all' })}
+            className="text-parque-purple hover:underline"
+          >
+            {language === 'es' ? 'Limpiar filtros' : 'Clear filters'}
+          </button>
         </div>
       ) : (
         <div className="text-center py-12 text-gray-500">


### PR DESCRIPTION
## Description
This PR adds search and round filter functionality to the results pages for players, matching the filters that already exist in the admin panel matches page.

## Changes

### 1. Player Results Tab (`components/player/ResultsTab.js`)
- Added search input to filter matches by player name
- Added round dropdown to filter matches by round
- Shows "X of Y matches" count when filters are applied
- Clear filters option when no results are found
- Bilingual support (Spanish/English)

### 2. Public League Results Page (`app/[location]/liga/[season]/page.js`)
- Added the same search and round filters to the public league page's Results tab
- Consistent UI/UX with the player results page
- Filters are responsive and work well on mobile and desktop

## Screenshots

### Player Results Tab
- Search by player name input field
- Filter by round dropdown
- Shows filtered results count

### Public League Results Tab  
- Same filters added for consistency
- Mobile-responsive layout

## Testing
- Search filter works by typing any part of either player's name
- Round filter shows all available rounds from matches
- Filters can be combined (search + round)
- Clear filters button appears when no results match
- All text is properly translated (Spanish/English)

## Benefits
- Users can quickly find specific matches they're looking for
- Better navigation through many match results
- Consistent experience between admin panel and player areas
- Mobile-friendly implementation