### PR TITLE
🐛 Fix Google Photos deletion not persisting

### DIFF
--- a/components/admin/clubs/ClubEditor.js
+++ b/components/admin/clubs/ClubEditor.js
@@ -118,6 +118,11 @@ export default function ClubEditor({ club, onSuccess, onCancel }) {
       main: '',
       gallery: [],
       googlePhotoReference: null
+    },
+
+    // Google Data (for Google Photos management)
+    googleData: {
+      photos: []
     }
   })
 
@@ -197,6 +202,9 @@ export default function ClubEditor({ club, onSuccess, onCancel }) {
           main: club.images?.main || '',
           gallery: club.images?.gallery || [],
           googlePhotoReference: club.images?.googlePhotoReference || null
+        },
+        googleData: {
+          photos: club.googleData?.photos || []
         }
       })
     }

--- a/components/admin/clubs/editor/ImagesSection.js
+++ b/components/admin/clubs/editor/ImagesSection.js
@@ -4,7 +4,13 @@ import ClubImageManager from '../ClubImageManager'
 
 export default function ImagesSection({ formData, handleChange, club }) {
   const handleImagesUpdate = (updatedClub) => {
+    // Update both images and googleData when available
     handleChange('images', updatedClub.images)
+    
+    // Also update googleData if it exists (for Google Photos deletion)
+    if (updatedClub.googleData) {
+      handleChange('googleData', updatedClub.googleData)
+    }
   }
 
   return (


### PR DESCRIPTION
## 🐛 Bug Fix: Google Photos Deletion Not Working

### **Problem**
Users could click the delete button for Google Photos, see a confirmation alert, confirm the deletion, but the photo would still appear after page refresh. The deletion wasn't being persisted to the database.

### **Root Cause**
The issue was in the data flow between components:

1. `ClubImageManager.js` correctly updated both `club.images` AND `club.googleData.photos` when deleting Google Photos
2. However, `ImagesSection.js` only passed the `images` part to the parent form via `handleChange('images', updatedClub.images)`, **completely ignoring the `googleData` changes**
3. `ClubEditor.js` wasn't managing `googleData` in its form state at all
4. So when the user clicked "Update Club", only the `images` changes were saved, but the Google Photos list (`googleData.photos`) remained unchanged

### **Solution**
Made two key changes:

#### **1. Fixed `ImagesSection.js`** - Now properly forwards both `images` AND `googleData` updates:
```javascript
const handleImagesUpdate = (updatedClub) => {
  // Update both images and googleData when available
  handleChange('images', updatedClub.images)
  
  // Also update googleData if it exists (for Google Photos deletion)
  if (updatedClub.googleData) {
    handleChange('googleData', updatedClub.googleData)
  }
}
```

#### **2. Fixed `ClubEditor.js`** - Now includes `googleData` in the form state:
```javascript
// Added to initial formData structure:
googleData: {
  photos: []
}

// Added proper initialization from club prop:
googleData: {
  photos: club.googleData?.photos || []
}
```

### **Testing**
✅ Delete button now properly removes Google Photos from the available list  
✅ Changes are persisted after page refresh  
✅ No console errors  
✅ Existing functionality (uploaded images, main image setting) remains intact  

### **What This Fixes**
- Google Photos deletion now works correctly and persists after page refresh
- Form state properly tracks all image-related changes
- No more "phantom" Google Photos that can't be deleted

The fix ensures the complete data flow: `ClubImageManager` → `ImagesSection` → `ClubEditor` → Database properly handles both `images` and `googleData` updates.