### PR TITLE
🔀 Phase 3: Signup/Registro unification with parameter mapping

### DIFF
--- a/PHASE3_CLEANUP_INSTRUCTIONS.md
+++ b/PHASE3_CLEANUP_INSTRUCTIONS.md
@@ -1,0 +1,47 @@
+# 🗑️ Phase 3 Cleanup - Delete Duplicate Registro File
+
+## File to Delete
+
+After merging this PR, manually delete this duplicate file:
+
+```bash
+# Delete the registro page (446 bytes)
+rm app/[locale]/registro/[ciudad]/page.js
+
+# Delete entire folder if it only contains page.js
+rm -rf app/[locale]/registro/
+```
+
+## ✅ How to Verify Phase 3 Works
+
+1. **Delete the file above**
+2. **Test Spanish signup URL:**
+   - Visit: `https://www.tenisdp.es/es/registro/marbella`
+   - Should work via Next.js rewrite to `/es/signup/marbella`
+   - Browser URL should remain `/es/registro/marbella` for SEO
+
+3. **Test English signup URL:**
+   - Visit: `https://www.tenisdp.es/en/signup/marbella`
+   - Should work normally
+
+## 🎯 What Phase 3 Achieves
+
+- ✅ **446 bytes code reduction** 
+- ✅ **SEO URLs preserved** - users still see `/es/registro/`
+- ✅ **Parameter mapping handled** - `[ciudad]` → `[city]` seamlessly
+- ✅ **No redirect loops** - unified page handles both locales
+- ✅ **Consistent pattern** - matches previous phases
+
+## 🔧 Key Innovation: Parameter Name Mapping
+
+**Challenge:** Spanish used `[ciudad]` parameter, English used `[city]`
+**Solution:** Unified page handles both: `const city = params.city || params.ciudad`
+
+## 🔄 Next: Phase 4 (Final!)
+
+After completing this cleanup, proceed to **Phase 4** (final):
+- Analyze `/rules/` vs `/reglas/` 
+- Handle `reglas/RulesPageContent.js` component file
+- Complete the internationalization cleanup
+
+**Phase 3 Complete! 🎉**

--- a/app/[locale]/signup/[city]/page.js
+++ b/app/[locale]/signup/[city]/page.js
@@ -1,16 +1,14 @@
 'use client'
 
-import { useParams, redirect } from 'next/navigation'
+import { useParams } from 'next/navigation'
 import CitySignupPageContent from '@/components/pages/CitySignupPageContent'
 
 export default function CitySignupPage() {
   const params = useParams()
   const locale = params.locale || 'en'
   
-  // If locale is not English, redirect to Spanish route
-  if (locale !== 'en') {
-    redirect(`/es/registro/${params.city}`)
-  }
+  // Get city parameter - works for both [city] and [ciudad] parameter names
+  const city = params.city || params.ciudad
   
-  return <CitySignupPageContent locale={locale} />
+  return <CitySignupPageContent locale={locale} city={city} />
 }

--- a/next.config.js
+++ b/next.config.js
@@ -48,6 +48,12 @@ const nextConfig = {
       {
         source: '/:locale(es)/ligas',
         destination: '/:locale/leagues'
+      },
+
+      // Phase 3: Signup/Registro rewrite (handles parameter name difference)
+      {
+        source: '/:locale(es)/registro/:ciudad',
+        destination: '/:locale/signup/:ciudad'
       }
     ]
   }


### PR DESCRIPTION
## 🎯 Phase 3: Signup/Registro Unification with Parameter Mapping

**Most complex phase yet** - handles parameter name differences `[city]` vs `[ciudad]`

## 📊 **Analysis**

**Current duplication:**
- `app/[locale]/signup/[city]/page.js` (446 bytes) - English with `[city]` param
- `app/[locale]/registro/[ciudad]/page.js` (446 bytes) - Spanish with `[ciudad]` param

**Key challenge:** Different parameter names + redirect logic between pages

## ✨ **Solution**

**Smart unification approach:**
1. **Next.js rewrite:** `/es/registro/[ciudad]` → `/es/signup/[ciudad]`
2. **Unified page:** Handles both `params.city` and `params.ciudad`
3. **No redirects:** Eliminates redirect loops
4. **SEO preserved:** Users still see `/es/registro/` URLs

## 🔧 **Key Innovation: Parameter Mapping**

```js
// Before: Separate pages with different params
// /signup/[city]/     - English
// /registro/[ciudad]/ - Spanish

// After: Unified page handles both
const city = params.city || params.ciudad
```

## 🚀 **Benefits**

- ✅ **446 bytes saved** (signup logic unified)
- ✅ **SEO URLs preserved** - users see `/es/registro/`
- ✅ **Parameter compatibility** - works with both names
- ✅ **No redirect loops** - cleaner architecture
- ✅ **Same functionality** - uses `CitySignupPageContent`

## 🧪 **Testing Checklist**

After merge + cleanup:
- [ ] Spanish URL: `/es/registro/marbella` → internal `/es/signup/marbella`
- [ ] English URL: `/en/signup/marbella` (direct)
- [ ] Browser shows `/es/registro/` for SEO
- [ ] No redirect loops

## 📁 **Files Changed**

- `next.config.js` - Added registro → signup rewrite
- `app/[locale]/signup/[city]/page.js` - Unified to handle both locales
- `PHASE3_CLEANUP_INSTRUCTIONS.md` - Manual cleanup steps

## 🔄 **Next Steps**

1. **Merge this PR**
2. **Delete** `app/[locale]/registro/[ciudad]/page.js`
3. **Test** Spanish registration URLs
4. **Proceed to Phase 4** (rules/reglas - final phase!)

---

## 📈 **Progress Tracker**

| Phase | Target | Status | Savings |
|-------|--------|---------|---------|
| **Phase 1** | clubs/clubes | ✅ Complete | 83KB+ |
| **Phase 2** | leagues/ligas | ✅ Complete | 143 bytes |
| **Phase 3** | signup/registro | 🔄 **This PR** | **446 bytes** |
| **Phase 4** | rules/reglas | 📋 Final phase | ~8KB |

**Total progress: 83KB+ eliminated, systematic cleanup working perfectly!** 🚀
